### PR TITLE
Handling for InvalidSequenceTokenException

### DIFF
--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -99,8 +99,14 @@ CloudWatchStream.prototype.putLogEvents = function (options, callback) {
     logStreamName: options.logStreamName,
     sequenceToken: options.nextSequenceToken
   }, function (err, data) {
-    options.nextSequenceToken = data && data.nextSequenceToken;
-    callback(err, options);
+    if (err && err.code === 'InvalidSequenceTokenException') {
+      const { expectedSequenceToken } = JSON.parse(this.httpResponse.body.toString())
+      options.nextSequenceToken = expectedSequenceToken;
+      self.putLogEvents(options, callback);
+    } else {
+      options.nextSequenceToken = data && data.nextSequenceToken;
+      callback(err, options);
+    }
   });
 };
 


### PR DESCRIPTION
When having multiple instances that log to the same log stream they may want to write in the same time using the same token.
The fix avoids losing the logs in this case.