### PR TITLE
Emit an event once the logs are successfully push / save

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Options:
   --stream                 AWS CloudWatch log stream name, overrides --prefix option.
   --interval               The maxmimum interval (in ms) before flushing the log
                            queue.                                [default: 1000]
+  --write_complete_event   Emit an event with this name once the logs are successfully
+                           push / save in AWS CloudWatch Logs
 ```
 ## Options
 
@@ -49,6 +51,12 @@ If you set this to `0` then it will only send logs when:
   * It reaches the maximum size of the logs
 
 __note__: Disabling the interval could mean that logs will *never* be sent to CloudWatch Logs.
+
+### `write_complete_event`: `String`
+
+The `write_complete_event` is the event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs.
+
+__note__: register the `write_complete_event` event handler in the stream's events object parameter.
 
 ### `aws_access_key_id`: `String`
 

--- a/bin/pino-cloudwatch.js
+++ b/bin/pino-cloudwatch.js
@@ -12,6 +12,7 @@ var argv = yargs
   .describe('prefix', 'AWS CloudWatch log stream name prefix')
   .describe('stream', 'AWS CloudWatch log stream name, overrides --prefix option')
   .describe('interval', 'The maxmimum interval (in ms) before flushing the log queue.')
+  .describe('write_complete_event', 'The event that will be emitted once the logs are successfully push / save in AWS CloudWatch Logs')
   .describe('stdout', 'Copy stdin to stdout')
   .demand('group')
   .default('interval', 1000)

--- a/lib/cloudwatch-stream.js
+++ b/lib/cloudwatch-stream.js
@@ -19,6 +19,7 @@ function CloudWatchStream (options) {
   this.logGroupName = options.group;
   this.logStreamName = options.stream || (options.prefix ? options.prefix + '-' : '') + os.hostname() + '-' + process.pid + '-' + new Date().getTime();
   this.nextSequenceToken = null;
+  this.writeCompleteEvent = options.write_complete_event || null;
 
   var awsOptions = {};
 
@@ -121,6 +122,11 @@ CloudWatchStream.prototype._write = function (chunks, encoding, callback) {
     }
 
     this.nextSequenceToken = options.nextSequenceToken;
+
+    if (this.writeCompleteEvent) {
+      this.emit(this.writeCompleteEvent);
+    }
+
     return callback();
   };
 


### PR DESCRIPTION
Emit an event once the logs are successfully push / save in AWS CloudWatch Logs